### PR TITLE
fixed frame change on in-call status bar

### DIFF
--- a/Sources/SideMenu/SideMenuController.swift
+++ b/Sources/SideMenu/SideMenuController.swift
@@ -480,6 +480,10 @@ open class SideMenuController: UIViewController {
                                                selector: #selector(SideMenuController.appDidEnteredBackground),
                                                name: UIApplication.didEnterBackgroundNotification,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(SideMenuController.didChangeStatusBarFrame),
+                                               name: UIApplication.didChangeStatusBarFrameNotification,
+                                               object: nil)
     }
 
     private func unregisterNotifications() {
@@ -490,6 +494,14 @@ open class SideMenuController: UIViewController {
     @objc private func appDidEnteredBackground() {
         if preferences.basic.hideMenuWhenEnteringBackground {
             hideMenu(animated: false)
+        }
+    }
+    
+    @objc private func didChangeStatusBarFrame() {
+        UIView.animate(withDuration: 0.25) {
+            self.menuContainerView.frame = self.sideMenuFrame(visibility: self.isMenuRevealed)
+            self.contentContainerView.frame = self.contentFrame(visibility: self.isMenuRevealed)
+            self.view.layoutIfNeeded()
         }
     }
 


### PR DESCRIPTION
it is better to implement logic on UIApplication.willChangeStatusBarFrameNotification notification for good animation, but it will take lots changes for frames. this one is hot fix and will change frame

It can be tested in simulator by Hardware - Toggle in-call Status bar

<img width="309" alt="Screen Shot 2020-02-07 at 13 43 28" src="https://user-images.githubusercontent.com/24361363/74023074-d7fce100-49af-11ea-9d8f-2607347473b3.png">