### PR TITLE
Fix isViewControllerInsideNavigationStack result when the view is embedded

### DIFF
--- a/Sources/SideMenu/SideMenuController.swift
+++ b/Sources/SideMenu/SideMenuController.swift
@@ -778,11 +778,17 @@ extension SideMenuController: UIGestureRecognizerDelegate {
         
         if let navigationController = viewController as? UINavigationController {
             return navigationController.viewControllers.count > 1
-        } else if let navigationController = viewController.navigationController {
-            if let index = navigationController.viewControllers.firstIndex(of: viewController) {
-                return index > 0
-            }
         }
+
+        var parent = viewController.parent
+        while parent != nil {
+            guard let navigationController = parent as? UINavigationController else {
+                parent = parent?.parent
+                continue
+            }
+            return navigationController.viewControllers.count > 0
+        }
+
         return false
     }
 

--- a/Sources/SideMenu/SideMenuController.swift
+++ b/Sources/SideMenu/SideMenuController.swift
@@ -778,15 +778,20 @@ extension SideMenuController: UIGestureRecognizerDelegate {
         
         if let navigationController = viewController as? UINavigationController {
             return navigationController.viewControllers.count > 1
-        }
-
-        var parent = viewController.parent
-        while parent != nil {
-            guard let navigationController = parent as? UINavigationController else {
-                parent = parent?.parent
-                continue
+        } else if let navigationController = viewController.navigationController {
+            if let index = navigationController.viewControllers.firstIndex(of: viewController) {
+                return index > 0
             }
-            return navigationController.viewControllers.count > 0
+        } else {
+            // Check if the ViewController is embedded
+            var parent = viewController.parent
+            while parent != nil {
+                guard let navigationController = parent as? UINavigationController else {
+                    parent = parent?.parent
+                    continue
+                }
+                return navigationController.viewControllers.count > 0
+            }
         }
 
         return false


### PR DESCRIPTION
I use embedded ViewController to split complex logic.
And I found the current logic of `isViewControllerInsideNavigationStack` can't handle this case.
The panGesture is triggered when I do swipe on the embedded viewController