### PR TITLE
Disable reveal on pan via delegate

### DIFF
--- a/Example/MenuViewController.swift
+++ b/Example/MenuViewController.swift
@@ -99,6 +99,11 @@ extension MenuViewController: SideMenuControllerDelegate {
         print("[Example] View controller did show [\(viewController)]")
     }
 
+    func sideMenuControllerShouldRevealMenu(_ sideMenuController: SideMenuController) -> Bool {
+        print("[Example] Returning true for shouldRevealMenu")
+        return true
+    }
+
     func sideMenuControllerWillHideMenu(_ sideMenuController: SideMenuController) {
         print("[Example] Menu will hide")
     }

--- a/Sources/SideMenu/Delegate.swift
+++ b/Sources/SideMenu/Delegate.swift
@@ -47,6 +47,13 @@ public protocol SideMenuControllerDelegate: AnyObject {
 
     // MARK: Revealing
 
+    /// Asks the delegate whether the side menu should be shown.
+    ///
+    /// Triggered by the pan gesture.
+    /// - Parameter sideMenuController: The side menu
+    /// - Returns: Whether the menu should be revealed.
+    func sideMenuControllerShouldRevealMenu(_ sideMenuController: SideMenuController) -> Bool
+
     /// Side menu is going to reveal.
     ///
     /// - Parameter sideMenu: The side menu

--- a/Sources/SideMenu/Delegate.swift
+++ b/Sources/SideMenu/Delegate.swift
@@ -89,6 +89,7 @@ public extension SideMenuControllerDelegate {
     func sideMenuController(_ sideMenuController: SideMenuController,
                             didShow viewController: UIViewController,
                             animated: Bool) {}
+    func sideMenuControllerShouldRevealMenu(_ sideMenuController: SideMenuController) -> Bool { return true }
     func sideMenuControllerWillRevealMenu(_ sideMenuController: SideMenuController) {}
     func sideMenuControllerDidRevealMenu(_ sideMenuController: SideMenuController) {}
     func sideMenuControllerWillHideMenu(_ sideMenuController: SideMenuController) {}

--- a/Sources/SideMenu/SideMenuController.swift
+++ b/Sources/SideMenu/SideMenuController.swift
@@ -751,6 +751,12 @@ extension SideMenuController: UIGestureRecognizerDelegate {
             return false
         }
 
+        if let shouldReveal = self.delegate?.sideMenuControllerShouldRevealMenu(self) {
+            guard shouldReveal else {
+                return false
+            }
+        }
+
         if isViewControllerInsideNavigationStack(for: touch.view) {
             return false
         }


### PR DESCRIPTION
I think it would be beneficial to be able to be able to dynamically disable the pan gesture when the user actually tries to perform it.

For a use-case example, I have some see-through modals that are shown in my app and the side menu can still be shown via the pan gesture. Using the sideMenuControllerShouldRevealMenu(_:) -> Bool method, the main side menu delegate can decide to not show it if a certain model or screen is currently shown.