### PR TITLE
Use Auto Layout to layout the contentContainerView instead of using f…

### DIFF
--- a/Sources/SideMenu/SideMenuController.swift
+++ b/Sources/SideMenu/SideMenuController.swift
@@ -172,8 +172,12 @@ open class SideMenuController: UIViewController {
             fatalError("[SideMenuSwift] `menuViewController` or `contentViewController` should not be nil.")
         }
 
-        contentContainerView.frame = view.bounds
         view.addSubview(contentContainerView)
+        contentContainerView.translatesAutoresizingMaskIntoConstraints = false
+        contentContainerView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        contentContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+        contentContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+        contentContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
 
         resolveDirection(with: contentContainerView)
 


### PR DESCRIPTION
…rame.  

Since user can use split view on iPadOS, The current approach to layout the `contentContainerView` can not adopt to different window size on iPad.  
Using Auto Layout to resolve this issue.